### PR TITLE
libpq-dev work around

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM jupyter/systemuser
 
 # Install psychopg2
 RUN apt-get update
-RUN apt-get -y install libssl-dev
 RUN apt-get -y install libpq-dev
 RUN pip3.4 install psycopg2
 RUN pip2.7 install psycopg2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM jupyter/systemuser
 
 # Install psychopg2
+RUN apt-get update
+RUN apt-get -y install libssl-dev
 RUN apt-get -y install libpq-dev
 RUN pip3.4 install psycopg2
 RUN pip2.7 install psycopg2


### PR DESCRIPTION
Encountered the following error when building image from source:

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/postgresql-9.3/libpq5_9.3.9-0ubuntu0.14.04_amd64.deb 404 Not Found [IP: 91.189.91.14 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/postgresql-9.3/libpq-dev_9.3.9-0ubuntu0.14.04_amd64.deb 404 Not Found [IP: 91.189.91.14 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Added the following to Dockerfile as a work around fix:

```
Install psycopg2
RUN apt-get update
RUN apt-get -y install libssl-dev
RUN apt-get -y install libpq-dev
RUN /usr/local/bin/pip3 install psycopg2
```
