### PR TITLE
Python tools install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,26 @@ FROM jupyter/systemuser
 # Install psychopg2
 RUN apt-get update
 RUN apt-get -y install libpq-dev
-RUN pip3.4 install psycopg2
-RUN pip2.7 install psycopg2
+RUN apt-get -y install python-pip
+RUN pip install psycopg2
+RUN pip2 install psycopg2
 
 # Install nano
 RUN apt-get -y install nano
 
 # Install terminado
-RUN pip2.7 install terminado
-RUN pip3.4 install terminado
+RUN pip2 install terminado
+RUN pip install terminado
 
 # Install scikit-learn
-RUN pip3.4 install scikit-learn==0.15
+RUN pip install scikit-learn==0.15
 
 # Install widgets
-RUN pip3.4 install ipywidgets
+RUN pip install ipywidgets
 
 # Install nbgrader
-RUN pip3.4 install --pre nbgrader
-RUN pip2.7 install --pre nbgrader
+RUN pip install --pre nbgrader
+RUN pip2 install --pre nbgrader
 
 # Install the nbgrader extensions
 RUN nbgrader extension install


### PR DESCRIPTION
In the original docker file the pip3.4 was install by the name of pip and pip2.7 was not install.

after install python-pip it install pip2 which correspond to pip2.7.
